### PR TITLE
Add option to disable adding source location to message

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -13,6 +13,10 @@ import (
 
 // formatOptions are options passed to a formatter.
 type formatOptions struct {
+	// AddSource indicates whether to compute the source code position of the
+	// log statement and add it as a prefix to the message.
+	AddSource bool
+
 	// Hostname is the host's name we send when connected to a remote syslog
 	// server.
 	Hostname string
@@ -70,7 +74,7 @@ func goFormat(_ context.Context, buf []byte, r slog.Record, opts formatOptions) 
 		buf = append(buf, ']', ' ')
 	}
 
-	if r.PC != 0 {
+	if opts.AddSource && r.PC != 0 {
 		fs := runtime.CallersFrames([]uintptr{r.PC})
 		f, _ := fs.Next()
 
@@ -123,7 +127,7 @@ func localFormat(_ context.Context, buf []byte, r slog.Record, opts formatOption
 		buf = append(buf, ']', ' ')
 	}
 
-	if r.PC != 0 {
+	if opts.AddSource && r.PC != 0 {
 		fs := runtime.CallersFrames([]uintptr{r.PC})
 		f, _ := fs.Next()
 

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -143,14 +144,16 @@ func TestLocalFormat(t *testing.T) {
 	}
 
 	opts := formatOptions{
-		Tag: "test",
+		Tag:       "test",
+		AddSource: false,
 	}
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			r := slog.NewRecord(testTime, slog.LevelInfo, "a message", 0)
+			pc, _, _, _ := runtime.Caller(0)
+			r := slog.NewRecord(testTime, slog.LevelInfo, "a message", pc)
 			r.AddAttrs(tc.attr)
 
 			buf := make([]byte, 0, 1024)

--- a/handler.go
+++ b/handler.go
@@ -13,6 +13,10 @@ import (
 
 // Options sets the syslog logging options.
 type Options struct {
+	// DontAddSource, if false, causes the handler to compute the source code
+	// position of the log statement and add it as a prefix to the message.
+	DontAddSource bool
+
 	// Level is the level at which we log at.
 	Level slog.Leveler
 
@@ -119,6 +123,7 @@ func (s *SyslogHandler) Handle(ctx context.Context, r slog.Record) error {
 	buf := *bufp
 
 	buf = s.formatter(ctx, buf, r, formatOptions{
+		AddSource: !s.opts.DontAddSource,
 		Hostname:  s.hostname,
 		Facility:  s.opts.Facility,
 		Tag:       s.opts.Tag,


### PR DESCRIPTION
First, thanks for publishing this package, it has saved me some effort :)

In some cases, it is undesirable to add the source location to log messages. The slog TextHandler by default doesn't add source, and offers an [AddSource](https://pkg.go.dev/log/slog#HandlerOptions) option to request it. SyslogHandler adds it by default, so to keep backward compatibility, add a DontAddSource option to turn it off.